### PR TITLE
Improve speed by taking unique cutpoints

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableTrees"
 uuid = "9113e207-2504-4b06-8eee-d78e288bee65"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "1.0.0"
+version = "1.0.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/test/forest.jl
+++ b/test/forest.jl
@@ -16,15 +16,15 @@ feature = 1
 @test ST._cutpoints(1:4, 3) == Float[1, 2, 3]
 @test ST._cutpoints([1, 3, 5, 7], 2) == Float[3, 5]
 
-@test ST._cutpoints(X, 2) == Float[1 2; 3 4]
-@test ST._cutpoints([3 4; 1 5; 2 6], 2) == Float[1 4; 2 5]
+@test ST._cutpoints(X, 2) == [Float[1, 3], Float[2, 4]]
+@test ST._cutpoints([3 4; 1 5; 2 6], 2) == [Float[1, 2], Float[4, 5]]
 
 let
     X = [1 1;
          1 3]
     classes = unique(y)
     colnames = ["A", "B"]
-    cutpoints = Float.(X)
+    cutpoints = ST._cutpoints(X, 2)
     splitpoint = ST._split(StableRNG(1), X, y, classes, colnames, cutpoints)
     # Obviously, feature (column) 2 is more informative to split on than feature 1.
     @test splitpoint.feature == 2


### PR DESCRIPTION
- Fixes #10 

## Benchmarks

Both on Julia 1.8.0-rc3 and after warmup.

`master`:

```
julia> @time _evaluate!(results, "titanic", StableForestClassifier, (; rng=_rng()));
  4.946664 seconds (9.15 M allocations: 9.076 GiB, 41.59% gc time)
```

This PR:

```
julia> @time _evaluate!(results, "titanic", StableForestClassifier, (; rng=_rng()));
  3.199879 seconds (5.41 M allocations: 5.337 GiB, 37.74% gc time)
```