### PR TITLE
Speedup `_view_y`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableTrees"
 uuid = "9113e207-2504-4b06-8eee-d78e288bee65"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -15,7 +15,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
-AbstractTrees = "0.3, 0.4"
+AbstractTrees = "0.3"
 CategoricalArrays = "0.10"
 InlineStrings = "1"
 MLJModelInterface = "1.4"

--- a/src/forest.jl
+++ b/src/forest.jl
@@ -97,8 +97,7 @@ function _cutpoints(X, q::Int)
 end
 
 "Return a view on all `y` for which the `comparison` holds in `X[:, feature]`."
-function _view_y(X, y, feature::Int, comparison, cutpoint)
-    data = view(X, :, feature)
+function _view_y(data, y, feature::Int, comparison, cutpoint)
     indexes_in_region = Bool[comparison(e, cutpoint) for e in data]
     return view(y, indexes_in_region)
 end
@@ -160,10 +159,11 @@ function _split(
     mc = max_split_candidates
     possible_features = mc == p ? (1:p) : _rand_subset(rng, 1:p, mc)
     for feature in possible_features
+        data = view(X, :, feature)
         for cutpoint in cutpoints[feature]
-            y_left = _view_y(X, y, feature, <, cutpoint)
+            y_left = _view_y(data, y, feature, <, cutpoint)
             length(y_left) == 0 && continue
-            y_right = _view_y(X, y, feature, ≥, cutpoint)
+            y_right = _view_y(data, y, feature, ≥, cutpoint)
             length(y_right) == 0 && continue
             gain = _information_gain(y, y_left, y_right, classes)
             if best_score ≤ gain

--- a/src/forest.jl
+++ b/src/forest.jl
@@ -218,9 +218,10 @@ nodevalue(node::Node) = node.splitpoint
 Return a view on all rows in `X` and `y` for which the `comparison` holds in `X[:, feature]`.
 """
 function _view_X_y(X, y, splitpoint::SplitPoint, comparison)
-    indexes_in_region = comparison.(X[:, splitpoint.feature], splitpoint.value)
-    X_view = view(X, indexes_in_region, :)
-    y_view = view(y, indexes_in_region)
+    data = view(X, :, splitpoint.feature)
+    mask = comparison.(data, splitpoint.value)
+    X_view = view(X, mask, :)
+    y_view = view(y, mask)
     return (X_view, y_view)
 end
 

--- a/test/forest.jl
+++ b/test/forest.jl
@@ -8,8 +8,9 @@ X = [1 2;
 y = [1, 2]
 
 feature = 1
-@test collect(ST._view_y(X, [1 2], feature, <, 2)) == [1]
-@test collect(ST._view_y(X, [1 2], feature, >, 2)) == [2]
+indexes = Vector{Bool}(undef, 2)
+@test collect(ST._view_y!(indexes, X, [1 2], feature, <, 2)) == [1]
+@test collect(ST._view_y!(indexes, X, [1 2], feature, >, 2)) == [2]
 
 @test ST._cutpoints([3, 1, 2], 2) == Float[1, 2]
 @test ST._cutpoints(1:9, 3) == Float[3, 5, 7]

--- a/test/forest.jl
+++ b/test/forest.jl
@@ -8,8 +8,8 @@ X = [1 2;
 y = [1, 2]
 
 indexes = Vector{Bool}(undef, 2)
-@test collect(ST._view_y!(indexes, X, [1 2], <, 2)) == [1]
-@test collect(ST._view_y!(indexes, X, [1 2], >, 2)) == [2]
+@test collect(ST._view_y!(indexes, X[:, 1], [1 2], <, 2)) == [1]
+@test collect(ST._view_y!(indexes, X[:, 1], [1 2], >, 2)) == [2]
 
 @test ST._cutpoints([3, 1, 2], 2) == Float[1, 2]
 @test ST._cutpoints(1:9, 3) == Float[3, 5, 7]

--- a/test/forest.jl
+++ b/test/forest.jl
@@ -7,10 +7,9 @@ X = [1 2;
      3 4]
 y = [1, 2]
 
-feature = 1
 indexes = Vector{Bool}(undef, 2)
-@test collect(ST._view_y!(indexes, X, [1 2], feature, <, 2)) == [1]
-@test collect(ST._view_y!(indexes, X, [1 2], feature, >, 2)) == [2]
+@test collect(ST._view_y!(indexes, X, [1 2], <, 2)) == [1]
+@test collect(ST._view_y!(indexes, X, [1 2], >, 2)) == [2]
 
 @test ST._cutpoints([3, 1, 2], 2) == Float[1, 2]
 @test ST._cutpoints(1:9, 3) == Float[3, 5, 7]


### PR DESCRIPTION
`_view_y` is the bottleneck according to the profiler. About 40-60% is spent there.

**Before (`main`):**

```julia
julia> @time _evaluate!(results, "titanic", StableForestClassifier, (; rng=_rng()));
  3.199879 seconds (5.41 M allocations: 5.337 GiB, 37.74% gc time)
```

**This PR:**

```julia
julia> @time _evaluate!(results, "titanic", StableForestClassifier, (; rng=_rng()));
  2.556027 seconds (2.80 M allocations: 2.331 GiB, 7.88% gc time)
```
 