### PR TITLE
Simplify show

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableTrees"
 uuid = "9113e207-2504-4b06-8eee-d78e288bee65"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -408,7 +408,7 @@ function StableRules(
 end
 
 "Return only the last result for the binary case because the other is 1 -p anyway."
-function _simplify_binary_probabilities(probs::AbstractVector)
+function _simplify_binary_probabilities(weight, probs::AbstractVector)
     if length(probs) == 2
         left = first(probs)
         right = last(probs)
@@ -419,16 +419,16 @@ function _simplify_binary_probabilities(probs::AbstractVector)
                 Please open an issue at StableTrees.jl.
                 """
         end
-        return right
+        return round(weight * right; digits=3)
     else
-        return probs
+        return round.(weight .* probs; digits=3)
     end
 end
 
 "Return a pretty formatted so that it is easy to understand."
-function _pretty_rule(rule::Rule)
-    then_probs = _simplify_binary_probabilities(rule.then_probs)
-    else_probs = _simplify_binary_probabilities(rule.else_probs)
+function _pretty_rule(weight, rule::Rule)
+    then_probs = _simplify_binary_probabilities(weight, rule.then_probs)
+    else_probs = _simplify_binary_probabilities(weight, rule.else_probs)
     condition = _pretty_path(rule.path)
     return "if $condition then $then_probs else $else_probs"
 end
@@ -439,9 +439,8 @@ function Base.show(io::IO, model::StableRules)
     println(io, "StableRules model with $l $rule_text:")
     for i in 1:l
         ending = i < l ? " +" : ""
-        rule = _pretty_rule(model.rules[i])
-        weight = model.weights[i]
-        println(io, " $weight * $rule", ending)
+        rule = _pretty_rule(model.weights[i], model.rules[i])
+        println(io, " $rule", ending)
     end
     C = model.classes
     lc = length(C)


### PR DESCRIPTION
- Fixes #21 

## Before

```
StableRules model with 10 rules:
 0.269 * if X[i, :x2] < 1.0 then 0.692 else 0.519 +
 0.15 * if X[i, :x3] ≥ 9.0 & X[i, :x2] ≥ 1.0 then 0.121 else 0.605 +
 0.15 * if X[i, :x1] ≥ 3.0 & X[i, :x2] < 1.0 then 0.467 else 0.605 +
 0.107 * if X[i, :x1] < 3.0 then 0.56 else 0.289 +
 0.098 * if X[i, :x3] < 9.0 then 0.67 else 0.432 +
 0.064 * if X[i, :x6] ≥ 10.5167 & X[i, :x3] < 9.0 then 0.84 else 0.551 +
 0.047 * if X[i, :x6] < 10.5167 then 0.297 else 0.518 +
 0.039 * if X[i, :x2] ≥ 1.0 & X[i, :x6] ≥ 8.6625 then 0.194 else 0.453 +
 0.039 * if X[i, :x2] ≥ 1.0 & X[i, :x6] ≥ 10.5167 then 0.22 else 0.408 +
 0.039 * if X[i, :x5] < 1.0 then 0.44 else 0.479
and 2 classes: [0.0, 1.0].
Note: showing only the probability for class 1.0 since class 0.0 has probability 1 - p.
```

## After

```
StableRules model with 10 rules:
 if X[i, :x2] < 1.0 then 0.186 else 0.14 +
 if X[i, :x3] ≥ 9.0 & X[i, :x2] ≥ 1.0 then 0.018 else 0.091 +
 if X[i, :x1] ≥ 3.0 & X[i, :x2] < 1.0 then 0.07 else 0.091 +
 if X[i, :x1] < 3.0 then 0.06 else 0.031 +
 if X[i, :x3] < 9.0 then 0.066 else 0.042 +
 if X[i, :x6] ≥ 10.5167 & X[i, :x3] < 9.0 then 0.054 else 0.035 +
 if X[i, :x6] < 10.5167 then 0.014 else 0.024 +
 if X[i, :x2] ≥ 1.0 & X[i, :x6] ≥ 8.6625 then 0.008 else 0.018 +
 if X[i, :x2] ≥ 1.0 & X[i, :x6] ≥ 10.5167 then 0.009 else 0.016 +
 if X[i, :x5] < 1.0 then 0.017 else 0.019
and 2 classes: [0.0, 1.0].
Note: showing only the probability for class 1.0 since class 0.0 has probability 1 - p.
```
