### PR TITLE
Fix wrong shuffling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StableTrees"
 uuid = "9113e207-2504-4b06-8eee-d78e288bee65"
 authors = ["Rik Huijzer <t.h.huijzer@rug.nl>"]
-version = "1.1.2"
+version = "1.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/StableTrees.jl
+++ b/src/StableTrees.jl
@@ -9,7 +9,7 @@ using InlineStrings: String255
 using LinearAlgebra: rank
 using MLJModelInterface: UnivariateFinite
 using PrecompileSignatures: @precompile_signatures
-using Random: AbstractRNG, default_rng, shuffle
+using Random: AbstractRNG, default_rng, seed!, shuffle
 using Statistics: mean, median
 using Tables: Tables, matrix
 

--- a/src/forest.jl
+++ b/src/forest.jl
@@ -323,7 +323,7 @@ end
 _elements(model::StableForest) = model.trees
 
 "Increase the state of `rng` by `i`."
-_change_rng_state!(rng::AbstractRNG, i::Int) = rand(rng, i)
+_change_rng_state!(rng::AbstractRNG, i::Int) = seed!(rng, i)
 
 """
 Return an unique and sorted vector of classes based on `y`.


### PR DESCRIPTION
This PR most likely fixes wrong shuffling.

Thanks to [David Hanak](https://github.com/dhanak) in https://github.com/JuliaAI/DecisionTree.jl/issues/194! :heart: :rocket: :tada: 

## Before

```
 Row │ Dataset   Model                   Hyperparameters    `nfolds`  AUC      1.96*SE
     │ String    String                  String             Int64     Float64  Float64
─────┼─────────────────────────────────────────────────────────────────────────────────
   1 │ blobs     LGBMClassifier          (;)                      10     0.99     0.02
   2 │ blobs     LGBMClassifier          (max_depth = 2,)         10     0.99     0.02
   3 │ blobs     StableRulesClassifier   (n_trees = 50,)          10     1.0      0.0
   4 │ titanic   LGBMClassifier          (;)                      10     0.87     0.03
   5 │ titanic   LGBMClassifier          (max_depth = 2,)         10     0.85     0.02
   6 │ titanic   StableForestClassifier  (n_trees = 1500,)        10     0.84     0.02
   7 │ titanic   StableRulesClassifier   (n_trees = 1500,)        10     0.83     0.02
   8 │ haberman  LGBMClassifier          (;)                      10     0.71     0.06
   9 │ haberman  LGBMClassifier          (max_depth = 2,)         10     0.68     0.06
  10 │ haberman  StableForestClassifier  (n_trees = 1500,)        10     0.69     0.06
  11 │ haberman  StableRulesClassifier   (n_trees = 1500,)        10     0.66     0.06
  12 │ boston    LGBMClassifier          (;)                      10     0.93     0.03
  13 │ boston    LGBMClassifier          (max_depth = 2,)         10     0.93     0.03
  14 │ boston    StableForestClassifier  (n_trees = 1500,)        10     0.94     0.03
  15 │ boston    StableRulesClassifier   (n_trees = 1500,)        10     0.9      0.02
```

## After

```
 Row │ Dataset   Model                   Hyperparameters    `nfolds`  AUC      1.96*SE
     │ String    String                  String             Int64     Float64  Float64
─────┼─────────────────────────────────────────────────────────────────────────────────
   1 │ blobs     LGBMClassifier          (;)                      10     0.99     0.02
   2 │ blobs     LGBMClassifier          (max_depth = 2,)         10     0.99     0.02
   3 │ blobs     StableRulesClassifier   (n_trees = 50,)          10     1.0      0.0
   4 │ titanic   LGBMClassifier          (;)                      10     0.87     0.03
   5 │ titanic   LGBMClassifier          (max_depth = 2,)         10     0.85     0.02
   6 │ titanic   StableForestClassifier  (n_trees = 1500,)        10     0.84     0.02
   7 │ titanic   StableRulesClassifier   (n_trees = 1500,)        10     0.85     0.02
   8 │ haberman  LGBMClassifier          (;)                      10     0.71     0.06
   9 │ haberman  LGBMClassifier          (max_depth = 2,)         10     0.68     0.06
  10 │ haberman  StableForestClassifier  (n_trees = 1500,)        10     0.7      0.05
  11 │ haberman  StableRulesClassifier   (n_trees = 1500,)        10     0.68     0.05
  12 │ boston    LGBMClassifier          (;)                      10     0.93     0.03
  13 │ boston    LGBMClassifier          (max_depth = 2,)         10     0.93     0.03
  14 │ boston    StableForestClassifier  (n_trees = 1500,)        10     0.94     0.02
  15 │ boston    StableRulesClassifier   (n_trees = 1500,)        10     0.91     0.02
```

## Conclusion of these tables

Accuracy remained the same or increased and 1.96*SE remained the same or decreased in all cases 🚀. So a strict improvement.